### PR TITLE
kconfig: Prevent using nano newlib library with mps2 devices

### DIFF
--- a/Kconfig.nrf
+++ b/Kconfig.nrf
@@ -51,7 +51,7 @@ config WARN_EXPERIMENTAL
 # Zephyr default is newlib and not newlib-nano for consistency between architectures.
 # To reduce FLASH footprint, newlib-nano is preferred default in NCS when newlib is selected.
 config NEWLIB_LIBC_NANO
-	default y
+	default y if SOC_FAMILY_NORDIC_NRF
 	depends on NEWLIB_LIBC && HAS_NEWLIB_LIBC_NANO
 
 # This is a temporary solution to whitelist


### PR DESCRIPTION
Prevents using the nano version of the newlib lirary when building for mps2 devices