### PR TITLE
scripts: memory-threshold-list: Rename the platform names

### DIFF
--- a/scripts/memory-threshold-list.yaml
+++ b/scripts/memory-threshold-list.yaml
@@ -1,7 +1,7 @@
 - scenarios:
     - sample.matter.template.release
   platforms:
-    - nrf52840dk_nrf52840
+    - nrf52840dk/nrf52840
   ram_size: 196608  # 25% free
   rom_size: 828928  # 150kB free
   rom_related_usage: 1024
@@ -14,7 +14,7 @@
 - scenarios:
     - sample.matter.template.debug
   platforms:
-    - nrf52840dk_nrf52840
+    - nrf52840dk/nrf52840
   ram_size: 196608  # 25% free
   rom_size: 880128  # 100kB free
   rom_related_usage: 2048
@@ -27,7 +27,7 @@
 - scenarios:
     - sample.matter.template.release
   platforms:
-    - nrf5340dk_nrf5340_cpuapp
+    - nrf5340dk/nrf5340/cpuapp
   ram_size: 393216  # 25% free
   rom_size: 824832  # 150kB free
   rom_related_usage: 1024
@@ -40,7 +40,7 @@
 - scenarios:
     - sample.matter.template.debug
   platforms:
-    - nrf5340dk_nrf5340_cpuapp
+    - nrf5340dk/nrf5340/cpuapp
   ram_size: 393216  # 25% free
   rom_size: 876032  # 100kB free
   rom_related_usage: 2048
@@ -54,7 +54,7 @@
 - scenarios:
     - sample.matter.template.release
   platforms:
-    - nrf7002dk_nrf5340_cpuapp
+    - nrf7002dk/nrf5340/cpuapp
   ram_size: 393216  # 25% free
   rom_size: 808448  # 150kB free
   rom_related_usage: 1024
@@ -67,7 +67,7 @@
 - scenarios:
     - sample.matter.template.debug
   platforms:
-    - nrf7002dk_nrf5340_cpuapp
+    - nrf7002dk/nrf5340/cpuapp
   ram_size: 393216  # 25% free
   rom_size: 910848  # 50kB free
   rom_related_usage: 2048
@@ -89,7 +89,7 @@
 - scenarios:
     - sample.nrf5340.multiprotocol_rpmsg
   platforms:
-    - nrf5340dk_nrf5340_cpunet
+    - nrf5340dk/nrf5340/cpunet
   ram_size: 55296
   rom_size: 235929
   codeowners:


### PR DESCRIPTION
HWMv2 introduces the new name concept of the platforms. The footprint requires correct platform names.