### PR TITLE
samples/nrf5340/extxio_smp_svr: Provide z_arm_platform_init at link time

### DIFF
--- a/samples/nrf5340/extxip_smp_svr/linker_arm_extxip.ld
+++ b/samples/nrf5340/extxip_smp_svr/linker_arm_extxip.ld
@@ -19,6 +19,10 @@
 #include <zephyr/linker/linker-defs.h>
 #include <zephyr/linker/linker-tool.h>
 
+
+/* Let SystemInit() be called in place of z_arm_platform_init() by default. */
+PROVIDE(z_arm_platform_init = SystemInit);
+
 /*
  * nRF5340dk and thingy53 are shipping QSPI external flashes.
  * These memories are mapped beginning from 0x1000_0000 internal SoC memory


### PR DESCRIPTION
This is alignment needed after introduction of:
https://github.com/zephyrproject-rtos/zephyr/pull/70977

Result is that SystemInit() is using directly in place of the z_arm_platform_ini().