### PR TITLE
cmake: Fix issues with board variables

### DIFF
--- a/cmake/multi_image.cmake
+++ b/cmake/multi_image.cmake
@@ -335,6 +335,8 @@ function(add_child_image_from_source)
       # Place the result in the CMake cache and remove local scoped variable.
       foreach(file CONF_FILE DTC_OVERLAY_FILE)
         if(DEFINED ${ACI_NAME}_${file})
+          zephyr_file_suffix(${ACI_NAME}_${file} SUFFIX ${${ACI_NAME}_FILE_SUFFIX})
+
           set(${ACI_NAME}_${file} ${${ACI_NAME}_${file}} CACHE STRING
             "Default ${ACI_NAME} configuration file" FORCE
             )
@@ -363,6 +365,7 @@ function(add_child_image_from_source)
       # Check for overlay named <ACI_NAME>.overlay.
       set(child_image_dts_overlay ${ACI_CONF_DIR}/${ACI_NAME}.overlay)
       if (EXISTS ${child_image_dts_overlay})
+        zephyr_file_suffix(child_image_dts_overlay SUFFIX ${${ACI_NAME}_FILE_SUFFIX})
         add_overlay_dts(${ACI_NAME} ${child_image_dts_overlay})
       endif()
     endif()
@@ -406,6 +409,12 @@ function(add_child_image_from_source)
           )
       endif()
     endforeach()
+
+    # Add FILE_SUFFIX to the preload file if it is set with the specific name of this image
+    file(APPEND
+         ${preload_file}
+         "set(FILE_SUFFIX \"${${ACI_NAME}_FILE_SUFFIX}\" CACHE INTERNAL \"NCS child image controlled\")\n"
+         )
 
     get_cmake_property(VARIABLES              VARIABLES)
     get_cmake_property(VARIABLES_CACHED CACHE_VARIABLES)


### PR DESCRIPTION
Fixes an issue with board variables when using the ncs_file function and propagates the FILE_SUFFIX variable to child image caches so it can be used if set for a specific image

NEEDS https://github.com/zephyrproject-rtos/zephyr/pull/71280 brought in as fromlist