### PR TITLE
samples: adjust include in nrf9160dk overlays to contain SoC

### DIFF
--- a/applications/serial_lte_modem/overlay-zephyr-modem-nrf9160dk-nrf52840.overlay
+++ b/applications/serial_lte_modem/overlay-zephyr-modem-nrf9160dk-nrf52840.overlay
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
-#include <nrf9160dk_uart1_on_if0_3.dtsi>
+#include <nrf9160/nrf9160dk_uart1_on_if0_3.dtsi>
 
 / {
 	chosen {

--- a/samples/bluetooth/hci_lpuart/boards/nrf9160dk_nrf52840.overlay
+++ b/samples/bluetooth/hci_lpuart/boards/nrf9160dk_nrf52840.overlay
@@ -1,7 +1,7 @@
 /* SPDX-License-Identifier: LicenseRef-Nordic-5-Clause */
 
-#include <nrf9160dk_nrf52840_reset_on_if5.dtsi>
-#include <nrf9160dk_uart1_on_if0_3.dtsi>
+#include <nrf52840/nrf9160dk_nrf52840_reset_on_if5.dtsi>
+#include <nrf52840/nrf9160dk_uart1_on_if0_3.dtsi>
 
 &pinctrl {
 	uart0_default_alt: uart0_default_alt {

--- a/samples/bluetooth/hci_lpuart/boards/nrf9160dk_nrf52840_0_14_0.overlay
+++ b/samples/bluetooth/hci_lpuart/boards/nrf9160dk_nrf52840_0_14_0.overlay
@@ -1,4 +1,4 @@
 /* SPDX-License-Identifier: LicenseRef-Nordic-5-Clause */
 
 /* Use the reset line that is available starting from v0.14.0 of the DK. */
-#include <nrf9160dk_nrf52840_reset_on_if9.dtsi>
+#include <nrf52840/nrf9160dk_nrf52840_reset_on_if9.dtsi>

--- a/samples/cellular/smp_svr/child_image/mcuboot/boards/nrf9160dk_nrf52840_0_14_0.overlay
+++ b/samples/cellular/smp_svr/child_image/mcuboot/boards/nrf9160dk_nrf52840_0_14_0.overlay
@@ -3,8 +3,8 @@
  *
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
-#include <nrf9160dk_nrf52840_reset_on_if9.dtsi>
-#include <nrf9160dk_uart1_on_if0_3.dtsi>
+#include <nrf52840/nrf9160dk_nrf52840_reset_on_if9.dtsi>
+#include <nrf52840/nrf9160dk_uart1_on_if0_3.dtsi>
 
 / {
 	board-control {

--- a/samples/cellular/smp_svr/nrf9160dk_nrf52840_mcumgr_srv.overlay
+++ b/samples/cellular/smp_svr/nrf9160dk_nrf52840_mcumgr_srv.overlay
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
-#include <nrf9160dk_uart1_on_if0_3.dtsi>
+#include <nrf52840/nrf9160dk_uart1_on_if0_3.dtsi>
 
 &pinctrl {
 	uart1_default: uart1_default {

--- a/tests/drivers/lpuart/boards/nrf9160dk_nrf52840.overlay
+++ b/tests/drivers/lpuart/boards/nrf9160dk_nrf52840.overlay
@@ -4,9 +4,9 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
-#include <nrf9160dk_nrf52840_reset_on_if5.dtsi>
+#include <nrf52840/nrf9160dk_nrf52840_reset_on_if5.dtsi>
 
-#include <nrf9160dk_uart1_on_if0_3.dtsi>
+#include <nrf52840/nrf9160dk_uart1_on_if0_3.dtsi>
 
 &pinctrl {
 	uart1_default_alt: uart1_default_alt {

--- a/tests/drivers/lpuart/boards/nrf9160dk_nrf52840_0_14_0.overlay
+++ b/tests/drivers/lpuart/boards/nrf9160dk_nrf52840_0_14_0.overlay
@@ -6,4 +6,4 @@
 
 
 /* Use the reset line that is available starting from v0.14.0 of the DK. */
-#include <nrf9160dk_nrf52840_reset_on_if9.dtsi>
+#include <nrf52840/nrf9160dk_nrf52840_reset_on_if9.dtsi>

--- a/tests/drivers/lpuart/boards/nrf9160dk_nrf9160.overlay
+++ b/tests/drivers/lpuart/boards/nrf9160dk_nrf9160.overlay
@@ -3,7 +3,7 @@
  *
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
-#include <nrf9160dk_nrf52840_reset_on_if5.dtsi>
+#include <nrf9160/nrf9160dk_nrf52840_reset_on_if5.dtsi>
 
 &gpiote {
 	interrupts = <13 NRF_DEFAULT_IRQ_PRIORITY>;

--- a/tests/drivers/lpuart/boards/nrf9160dk_nrf9160_0_14_0.overlay
+++ b/tests/drivers/lpuart/boards/nrf9160dk_nrf9160_0_14_0.overlay
@@ -5,4 +5,4 @@
  */
 
 /* Use the reset line that is available starting from v0.14.0 of the DK. */
-#include <nrf9160dk_nrf52840_reset_on_if9.dtsi>
+#include <nrf9160/nrf9160dk_nrf52840_reset_on_if9.dtsi>

--- a/tests/drivers/lpuart/boards/nrf9160dk_nrf9160_loopback.overlay
+++ b/tests/drivers/lpuart/boards/nrf9160dk_nrf9160_loopback.overlay
@@ -3,7 +3,7 @@
  *
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
-#include <nrf9160dk_nrf52840_reset_on_if5.dtsi>
+#include <nnrf9160/rf9160dk_nrf52840_reset_on_if5.dtsi>
 
 &gpiote {
 	interrupts = <13 NRF_DEFAULT_IRQ_PRIORITY>;


### PR DESCRIPTION
HWMv2 unifies nrf9160dk/nrf9160 and nrf9160dk/nrf52840 boards in a single folder.

Therefore the inclusion of common overlays are placed in folders named according to the SoC in use.

Update overlays in samples and tests to include the correct dtsi based on the SoC in use.